### PR TITLE
Add potentially missing CONSOLE_X_BELL

### DIFF
--- a/src/bsd_kbd.c
+++ b/src/bsd_kbd.c
@@ -287,6 +287,10 @@ KbdOff(InputInfoPtr pInfo, int what)
     return Success;
 }
 
+#ifndef CONSOLE_X_BELL
+#define CONSOLE_X_BELL _IOW('t',123,int[2])
+#endif
+
 static void
 SoundBell(InputInfoPtr pInfo, int loudness, int pitch, int duration)
 {


### PR DESCRIPTION
The CONSOLE_* macros used to be in xf86_OSlib.h, but there's an MR moving them into Xserver's bsd specific init code, since it's the only consumer, with the little exception CONSOLE_X_BELL also used by this driver.

According to comments in the Xserver, these macros seem to originate from some other, probably platform specific, header "ioctl_pc.h", but couldn't find any trace where that actually came from.